### PR TITLE
Introduce Dedicated Landing Page for API Companion

### DIFF
--- a/companion_app/app/assets/config/manifest.js
+++ b/companion_app/app/assets/config/manifest.js
@@ -1,2 +1,3 @@
 //= link_tree ../javascripts .js
 //= link application.scss
+//= link application.css

--- a/companion_app/app/controllers/home_controller.rb
+++ b/companion_app/app/controllers/home_controller.rb
@@ -1,0 +1,4 @@
+class HomeController < ApplicationController
+  def index
+  end
+end

--- a/companion_app/app/helpers/home_helper.rb
+++ b/companion_app/app/helpers/home_helper.rb
@@ -1,0 +1,2 @@
+module HomeHelper
+end

--- a/companion_app/app/views/home/index.html.erb
+++ b/companion_app/app/views/home/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Home#index</h1>
+<p>Find me in app/views/home/index.html.erb</p>

--- a/companion_app/app/views/home/index.html.erb
+++ b/companion_app/app/views/home/index.html.erb
@@ -1,2 +1,22 @@
-<h1>Home#index</h1>
-<p>Find me in app/views/home/index.html.erb</p>
+<% content_for :page_title, "Welcome to the Restaurant Recommendation app!" %>
+
+
+<div class="landing-page">
+  <section class="description">
+    <div class="govuk-width-container">
+      <p class="govuk-body-l">Get personalized takeout recommendations with just a few clicks. Find the best local restaurants tailored to your taste!</p>
+      <%= link_to "Get Started", new_recommendation_path, class: "govuk-button" %>
+    </div>
+  </section>
+
+  <section class="how-it-works">
+    <div class="govuk-width-container">
+      <h2 class="govuk-heading-m">How It Works</h2>
+      <ol class="govuk-list govuk-list--number">
+        <li>Set your preferences.</li>
+        <li>Our system fetches matching restaurant data.</li>
+        <li>Receive personalized recommendations.</li>
+      </ol>
+    </div>
+  </section>
+</div>

--- a/companion_app/app/views/recommendations/new.html.erb
+++ b/companion_app/app/views/recommendations/new.html.erb
@@ -1,4 +1,5 @@
 <% content_for :page_title, "Restaurant Recommendations" %>
+<% content_for :back_link, root_path %>
 
 <%= form_with url: recommendations_path, method: :post, local: true, html: { id: "recommendation-form" } do |form| %>
   <div>

--- a/companion_app/config/routes.rb
+++ b/companion_app/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
-  root "recommendations#new"
+  get "home/index"
+  root "home#index"
   resources :recommendations, only: [ :new, :create ]
   mount GovukPublishingComponents::Engine, at: "/component-guide" if Rails.env.development?
 

--- a/companion_app/spec/helpers/home_helper_spec.rb
+++ b/companion_app/spec/helpers/home_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the HomeHelper. For example:
+#
+# describe HomeHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe HomeHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/companion_app/spec/requests/home_spec.rb
+++ b/companion_app/spec/requests/home_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe "Homes", type: :request do
+  describe "GET /index" do
+    it "returns http success" do
+      get "/home/index"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/companion_app/spec/requests/home_spec.rb
+++ b/companion_app/spec/requests/home_spec.rb
@@ -7,5 +7,4 @@ RSpec.describe "Homes", type: :request do
       expect(response).to have_http_status(:success)
     end
   end
-
 end

--- a/companion_app/spec/views/home/index.html.erb_spec.rb
+++ b/companion_app/spec/views/home/index.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "home/index.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
This PR introduces a new landing page for the API Companion application to replace the default recommendations page. The goal is to provide a more engaging and informative entry point that clearly communicates the purpose of the app and guides users seamlessly into the app's core functionality.